### PR TITLE
playerテーブルedit追加[WIP]

### DIFF
--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -26,9 +26,33 @@ class PlayersController < ApplicationController
       end
   end
 
+  def edit
+     @player = Player.find_by(id: params[:id])
+     @positions = Position.all
+  end
+
+  def update
+     @player = Player.find_by(id: params[:id])
+     @positions = Position.all
+      ActiveRecord::Base.transaction do
+        @player.update!(player_params)
+          positions_ids = params[:positions]
+            positions_ids.each do |position_id|              
+              PlayerPosition.update!(player_id: @player.id, position_id: position_id)            
+            end
+          flash[:success] = "登録が完了しました。"
+          redirect_to root_path  
+      rescue
+          binding.pry
+        flash[:danger] = "必須項目を入力してください。"
+        render :new
+      end
+  end
+
   private
   
     def player_params 
       params.require(:player).permit(:gender, :prefecture, :comment, :available_day, position_id:[] )
     end
+
 end

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -50,6 +50,13 @@ class PlayersController < ApplicationController
       end
   end
 
+  def destroy
+    @player = Player.find_by(id: params[:id])
+      @player.destroy!
+      flash[:success] = "登録が完了しました。"
+      render :root_path
+  end
+
   private
   
     def player_params 

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -34,16 +34,17 @@ class PlayersController < ApplicationController
   def update
      @player = Player.find_by(id: params[:id])
      @positions = Position.all
+     select_positions = @player.PlayerPositions
       ActiveRecord::Base.transaction do
         @player.update!(player_params)
+        select_positions.clear
           positions_ids = params[:positions]
             positions_ids.each do |position_id|              
-              PlayerPosition.update!(player_id: @player.id, position_id: position_id)            
+              PlayerPosition.create!(player_id: @player.id, position_id: position_id)            
             end
           flash[:success] = "登録が完了しました。"
           redirect_to root_path  
       rescue
-          binding.pry
         flash[:danger] = "必須項目を入力してください。"
         render :new
       end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,6 +1,6 @@
 class Player < ApplicationRecord
   belongs_to :user
-  has_many :PlayerPositions
+  has_many :PlayerPositions, dependent: :destroy
   has_many :positions, through: :PlayerPositions
   accepts_nested_attributes_for :PlayerPositions, allow_destroy: true
 

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -2,6 +2,7 @@ class Player < ApplicationRecord
   belongs_to :user
   has_many :PlayerPositions
   has_many :positions, through: :PlayerPositions
+  accepts_nested_attributes_for :PlayerPositions, allow_destroy: true
 
   validates :gender, :exclusion => ['未入力']
   validates :available_day, :exclusion => ['未入力']

--- a/app/views/players/edit.html.erb
+++ b/app/views/players/edit.html.erb
@@ -1,0 +1,37 @@
+<% provide(:title,"プレイヤー情報編集 ")%>
+
+<div class="container-login p-4">
+<h1>プレイヤー情報編集</h1>
+  <%= form_for  @player do |f| %>
+     
+    <div class="form-group">
+      <%= f.label :gender, "性別（必須）"%>
+      <%= f.select :gender, Player.genders.keys, class: "form-control"%>          
+    </div>
+
+    <div class="form-group">
+      <%= f.label :prefecture, '地域(必須)'%>
+      <%= f.select :prefecture, Player.prefectures.keys,　class: 'form-control'%>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :available_day, '練習参加可能日（必須）'%>
+      <%= f.select :available_day, Player.available_days.keys, class: 'form-control'%>
+    </div>
+
+    <div class="form-group">
+      <%= f.label 'ポジション（複数選択可）'%><br>
+      <% @positions.each do |category| %>
+        <%= check_box_tag "positions[]", category.id%>
+        <%= category.display_name %>
+      <% end %>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :comment, 'フリーコメント'%>
+      <%= f.text_area :comment,class:'form-control'%>
+    </div>
+     
+    <%= f.submit "登録する", class: "btn btn-primary" %>
+  <% end %>
+</div>

--- a/app/views/players/index.html.erb
+++ b/app/views/players/index.html.erb
@@ -10,7 +10,6 @@
       <div class="player_data">
         <%= link_to "#{player.user.nickname}さん", user_path(player.user.id)%><br>
         <%= player.gender %>
-        <%= player.prefecture %>
         <%= player.available_day%>
         <%= player.positions.pluck(:display_name).join(", ") %><br>
         <%= player.comment%><br>

--- a/app/views/players/index.html.erb
+++ b/app/views/players/index.html.erb
@@ -15,7 +15,7 @@
         <%= player.comment%><br>
         <% if current_user.player == player %>
           <%= link_to '編集', edit_player_path(player.id),class:"btn btn-primary mr-3" %>
-          <%= link_to '削除', player,method: :delete,data:{confirm: "プレイヤー情報を削除します。よろしいですか？"},class: 'btn btn-primary' %>
+          <%= link_to '削除', player,method: :destroy,data:{confirm: "プレイヤー情報を削除します。よろしいですか？"},class: 'btn btn-primary' %>
         <% end %>
       </div>
     <%end%>


### PR DESCRIPTION
### 内容
playerテーブルの編集機能の追加
edit.html.erb作成
player_controllerへedit.updateアクションの追加
### 困っている部分
playerテーブルのupdateの際に現在ログイン中のプレイヤーと関連づいている中間テーブル「player_positions」を一度すべてdeleteし、新たに中間テーブルを作り直す挙動にしたいのだが期待する動作にならない。